### PR TITLE
Change deprecated Bundler method

### DIFF
--- a/lib/tenter/helpers.rb
+++ b/lib/tenter/helpers.rb
@@ -10,7 +10,7 @@ module Tenter
 
       msg = "X-Hub-Signature header did not match"
       halt 403, msg unless Tenter::Utils.dir_exists? params[:site_dir]
-      
+
       secret = Tenter::Utils.secret params[:site_dir]
 
       request_sig = request.env['HTTP_X_HUB_SIGNATURE']
@@ -19,7 +19,7 @@ module Tenter
                      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
                                              secret,
                                              request_body)
-      
+
       msg = "X-Hub-Signature header did not match"
       halt 403, msg unless Rack::Utils.secure_compare computed_sig, request_sig
     end
@@ -34,8 +34,8 @@ module Tenter
       msg = ts + "Initiating: #{command["path"]}\n"
       Tenter::Utils.append_to_log command["log"], msg
 
-      pid = if defined?(Bundler) && Bundler.respond_to?(:with_clean_env)
-              Bundler.with_clean_env { command["proc"].call }
+      pid = if defined?(Bundler) && Bundler.respond_to?(:with_original_env)
+              Bundler.with_original_env { command["proc"].call }
             else
               command["proc"].call
             end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -39,7 +39,7 @@ class TenterTest < Minitest::Test
     Tenter.settings = { doc_root: "doc_root" }
     assert_equal "doc_root", Tenter.settings[:doc_root]
   end
-  
+
   def test_root
     get "/"
     assert_equal 404, last_response.status
@@ -75,7 +75,7 @@ class TenterTest < Minitest::Test
     statement = "Initiating: #{command["path"]}"
     time_re = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+\d{4}/
     re = /\[#{time_re}\] #{statement}\n\[#{time_re}\] Hello world\n/
-    
+
     post path("cmd", "some_dir"), nil, valid_sig
     assert_equal 200, last_response.status
     assert_equal "Command initiated", last_response.body


### PR DESCRIPTION
The Bundler method `with_clean_env` has been deprecated. The recommendation is to use `with_unbundled_env` but I think what I really want is `with_original_env` so this PR switches to that instead.

It also cleans up some trailing whitespace.